### PR TITLE
closes #355, closes #356

### DIFF
--- a/build/mirador/css/mirador-combined.css
+++ b/build/mirador/css/mirador-combined.css
@@ -2695,7 +2695,7 @@ li.highlight {
   top:10px;
   bottom:0;
   list-style-type:none;
-  font-size: 90%;
+  font-size: 75%;
 }
 .toc a.toc-link {
   color: black;

--- a/css/mirador.css
+++ b/css/mirador.css
@@ -506,7 +506,7 @@ li.highlight {
   top:10px;
   bottom:0;
   list-style-type:none;
-  font-size: 90%;
+  font-size: 75%;
 }
 .toc a.toc-link {
   color: black;

--- a/js/src/widgets/hud.js
+++ b/js/src/widgets/hud.js
@@ -36,6 +36,11 @@
       } else {
         this.parent.parent.bottomPanelVisibility(this.parent.parent.bottomPanelVisible);
       }
+      
+      //by default, minimized bottom panel if there is only one image for this object
+      if (this.parent.imagesList.length === 1) {
+        this.parent.parent.bottomPanelVisibility(false);      
+      }
     },
 
     bindEvents: function() {


### PR DESCRIPTION
reduce TOC font sizes to 75% and by default, single image objects have bottom thumb panel minimized