### PR TITLE
Fix for issue #481 - dead click spots in ManifestListItems

### DIFF
--- a/js/src/viewer/manifestListItem.js
+++ b/js/src/viewer/manifestListItem.js
@@ -108,7 +108,7 @@
         jQuery(this).hide().fadeIn(600);
       });
 
-      this.element.find('.select-metadata').on('click', function() {
+      this.element.on('click', function() {
         var windowConfig = {
           manifest: _this.manifest,
           currentCanvasID: null,
@@ -117,7 +117,8 @@
         $.viewer.workspace.addWindow(windowConfig);
       });
 
-      this.element.find('.preview-image').on('click', function() {
+      this.element.find('.preview-image').on('click', function(e) {
+        e.stopPropagation();
         var windowConfig = {
           manifest: _this.manifest,
           currentCanvasID: jQuery(this).attr('data-image-id'),


### PR DESCRIPTION
Proposed fix: basically just attaches the event handler one level higher, and does stopPropagation in the handlers for the thumbnails.  